### PR TITLE
Use ralsina's forked docopt instead of original version.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,4 +10,4 @@ license: MIT
 
 dependencies:
   docopt:
-    github: chenkovsky/docopt.cr
+    github: ralsina/docopt.cr


### PR DESCRIPTION
More detail, checking following link:

https://forum.crystal-lang.org/t/wired-compiler-error-bug-called-type-id-for-array-config-class-crystal-virtualmetaclasstype-exception/7400